### PR TITLE
Rewrite update

### DIFF
--- a/config/rewrites.example.yml
+++ b/config/rewrites.example.yml
@@ -1,6 +1,11 @@
-# Tip: Requesting /herp?test=1 is a good test of ordered, chained redirections
-# and shows non-regexp "from" requires an exact match & doesn't prefix match
-# with third rule's "from" '/test' not matching redirected '/test/1'
+# Tip: Requesting /herp_alias?test=1 is good test of ordered, chained redirects
+# and shows non-regexp "from" requires an exact match
+# by not prefix matching fourth rule's "from" value '/test'
+# against redirected '/test/1'
+-
+    method:     rewrite
+    from:       /herp_alias
+    to:         /herp
 -
     method:     r301
     from:       /herp
@@ -19,10 +24,6 @@
     method:     r303
     from:       /test
     to:         /testyourmight
--
-    method:     rewrite
-    from:       /about_alias
-    to:         /about
 -
     method:     r307
     from:       !ruby/regexp '/^\/warp\/[1-9]$/i'

--- a/config/rewrites.yml
+++ b/config/rewrites.yml
@@ -1,12 +1,12 @@
 # XSL
 -
-    method:     r301
+    method:     rewrite
     from:       !ruby/regexp /^\/(?:php\/xslt\.php|read\/)\?&?_xmlsrc=(?:http:\/\/lewisandclarkjournals\.unl\.edu\/files\/xml\/)?(.+)&_xslsrc=(?:http:\/\/lewisandclarkjournals\.unl\.edu\/)?LCstyles\.xsl$/
     to:         /item/$1
     options:
         no_qs:  1
 -
-    method:     r301
+    method:     rewrite
     from:       !ruby/regexp /^\/(?:php\/xslt\.php|read\/)\?&?_xslsrc=(?:http:\/\/lewisandclarkjournals\.unl\.edu\/)?LCstyles\.xsl&_xmlsrc=(?:http:\/\/lewisandclarkjournals\.unl\.edu\/files\/xml\/)?(.+)$/
     to:         /item/$1
     options:


### PR DESCRIPTION
Closes #42 in first commit.

Second commit improves CDRH::Rewrite to address multiple redirect inefficiency.
I hadn't considered the problem until writing the rules for L&C and hadn't thought of such a relatively simple solution to it until now.