### PR TITLE
Fix blank searches returning error page

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,7 +52,9 @@ class ItemsController < ApplicationController
     options = ActionController::Parameters.new(aParams)
     # make sure that empty search terms go through okay
     if !options[:qtext].nil? && options[:qtext].empty?
-      options[:qtext] = "*"
+      options.delete("qfield")
+      options.delete("qtext")
+      @search_bool = true
     end
 
     # filter queries (facets)


### PR DESCRIPTION
Was returning "maxClauseCount" exceeded error
Searching with * expands to # of indexed records as OR clauses

Remove qfield and qtext parameters to prevent expansion
Set @search_bool = true so Solr results are displayed

Fixes #124 