### PR TITLE
adds subcategory to date search on adv search page

### DIFF
--- a/app/views/search_partials/_author_year.html.erb
+++ b/app/views/search_partials/_author_year.html.erb
@@ -50,28 +50,28 @@
   <h4>Year</h4>
   <div class="row">
     <div class="col-md-3">
-      <%= link_to search_path({:date_from => ["1803"], :date_to => ["1803"]}) do %>
+      <%= link_to search_path({:subCategory => "Journal Entries", :date_from => ["1803"], :date_to => ["1803"]}) do %>
         <div class="panel panel-default">
           <div class="panel-body">1803</div>
         </div>
       <% end %>
     </div>
     <div class="col-md-3">
-      <%= link_to search_path({:date_from => ["1804"], :date_to => ["1804"]}) do %>
+      <%= link_to search_path({:subCategory => "Journal Entries", :date_from => ["1804"], :date_to => ["1804"]}) do %>
         <div class="panel panel-default">
           <div class="panel-body">1804</div>
         </div>
       <% end %>
     </div>
     <div class="col-md-3">
-      <%= link_to search_path({:date_from => ["1805"], :date_to => ["1805"]}) do %>
+      <%= link_to search_path({:subCategory => "Journal Entries", :date_from => ["1805"], :date_to => ["1805"]}) do %>
         <div class="panel panel-default">
           <div class="panel-body">1805</div>
         </div>
       <% end %>
     </div>
     <div class="col-md-3">
-      <%= link_to search_path({:date_from => ["1806"], :date_to => ["1806"]}) do %>
+      <%= link_to search_path({:subCategory => "Journal Entries", :date_from => ["1806"], :date_to => ["1806"]}) do %>
         <div class="panel panel-default">
           <div class="panel-body">1806</div>
         </div>


### PR DESCRIPTION
fixes https://github.com/CDRH/lewisandclark/issues/171

Other possible solutions explored including adding params:

`:all => "true"`
`:qtext => ""`

I chose to restrict the subCategory because it made the most sense to me that people would want to search only the journals from that date.  If this is not the correct assumption, we can certainly switch it out.