### PR TITLE
Enable Force SSL for proper HTTPS config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,11 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+
+  # Handle STS here instead of Apache, or Rails duplicates header contents
+  # Also unset cache-control header in HTTPS vhost for same reason
+  config.ssl_options = { hsts: { preload: true } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -21,4 +21,6 @@ Rails.application.config.active_record.belongs_to_required_by_default = true
 ActiveSupport.halt_callback_chains_on_return_false = false
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
-Rails.application.config.ssl_options = { hsts: { subdomains: true } }
+if Rails.application.config.ssl_options[:hsts].nil? || Rails.application.config.ssl_options[:hsts][:subdomains].nil?
+  Rails.application.config.ssl_options[:hsts][:subdomains] = true
+end

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -21,6 +21,10 @@ Rails.application.config.active_record.belongs_to_required_by_default = true
 ActiveSupport.halt_callback_chains_on_return_false = false
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
-if Rails.application.config.ssl_options[:hsts].nil? || Rails.application.config.ssl_options[:hsts][:subdomains].nil?
+if Rails.application.config.ssl_options[:hsts].nil?
+  Rails.application.config.ssl_options[:hsts] = {}
+end
+
+if Rails.application.config.ssl_options[:hsts][:subdomains].nil?
   Rails.application.config.ssl_options[:hsts][:subdomains] = true
 end


### PR DESCRIPTION
Add "preload" to STS header,
to have option to add to browser preload lists in future

Solve problem of app not using env config.ssl_options value
because of override from initializer changing defaults in Rails 5