### PR TITLE
Remove unwanted submit_tag attributes

### DIFF
--- a/app/views/items/map.html.erb
+++ b/app/views/items/map.html.erb
@@ -29,7 +29,7 @@
   <%= hidden_field_tag(:qfield, "text") %>
   <%= text_field_tag(:qtext, params[:qtext], :placeholder => "Search for...", :class => "form-control") %>
   <span class="input-group-btn">
-    <%= submit_tag("Search", :class => "btn btn-primary") %>
+    <%= submit_tag "Search", class: "btn btn-primary", name: nil, data: { disable_with: false } %>
   </span>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,7 +80,7 @@
                       id: "main_site_search", placeholder: "Search All Items",
                       class: "form-control" %>
                   <div class="input-group-btn">
-                    <%= submit_tag "Search", class: "btn btn-default" %>
+                    <%= submit_tag "Search", class: "btn btn-default", name: nil, data: { disable_with: false } %>
                   </div>
                 </div><!-- /input-group -->
                 <%= link_to search_path, class: "btn btn-link pull-right" do %>

--- a/app/views/search_partials/_date_limit.html.erb
+++ b/app/views/search_partials/_date_limit.html.erb
@@ -47,7 +47,7 @@
       <%= hidden_field_tag(:qtext, params["qtext"]) %>
 
       <div class="clearfix buffer-bottom-sm">
-        <%= submit_tag("Filter", :class => "btn btn-primary buffer-right-sm") %>
+        <%= submit_tag "Filter", class: "btn btn-primary buffer-right-sm", name: nil, data: { disable_with: false } %>
 
         <button type="button" class="btn btn-link glyphicon glyphicon-question-sign pull-right"
           data-toggle="collapse" data-target="#date_help"

--- a/app/views/search_partials/_searchbox.html.erb
+++ b/app/views/search_partials/_searchbox.html.erb
@@ -12,7 +12,7 @@
               <%= render partial: "search_partials/facet_hidden_fields" %>
 
               <span class="input-group-btn">
-                <%= submit_tag("Search", :class => "btn btn-primary") %>
+                <%= submit_tag "Search", class: "btn btn-primary", name: nil, data: { disable_with: false } %>
               </span>
             <% end %>
             <%= render partial: "search_partials/help" %>

--- a/app/views/static/journals.html.erb
+++ b/app/views/static/journals.html.erb
@@ -98,7 +98,7 @@
 
           <div class="row">
             <div class="col-md-12">
-              <%= submit_tag "Search", class: "btn btn-primary pull-right" %>
+              <%= submit_tag "Search", class: "btn btn-primary pull-right", name: nil, data: { disable_with: false } %>
 
               <button type="button"
                 class="btn btn-link glyphicon glyphicon-question-sign"


### PR DESCRIPTION
Empty name attribute to prevent extra query string parameter
Don't see any explanation why this is set in Rails API / source

Remove data-disable-with attr which disables submit after pressed
Makes sense for preventing double-clicks with e-commerce, but breaks
submitting a different search after a submit & "back" via browser